### PR TITLE
source.fixAll uses explicit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   },
   "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": [
     "json",


### PR DESCRIPTION
* VSCode seems to change true to explicit
* see docs: https://code.visualstudio.com/updates/v1_83#_code-actions-on-save-and-auto-save